### PR TITLE
change: use gh-pages domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://bitcoin-dev.blog"
+baseURL = "https://bitcoin-dev.github.io/blog"
 languageCode = "en-us"
 title = "bitcoin-dev blog"
 

--- a/content/blog/bitcoin-core-usdt-support.md
+++ b/content/blog/bitcoin-core-usdt-support.md
@@ -80,7 +80,7 @@ that shows the communication between two peers in real-time. Users can find this
 script alongside other [USDT examples] in the `contrib/tracing/` directory of the
 Bitcoin Core repository.
 
-{{< tweet 1396889721859715077 >}}
+{{< tweet user="0xb10c" id="1396889721859715077" >}}
 
 [placed two tracepoints]: https://github.com/bitcoin/bitcoin/commit/4224dec22baa66547303840707cf1d4f15a49b20
 [USDT examples]: https://github.com/bitcoin/bitcoin/tree/master/contrib/tracing
@@ -124,7 +124,7 @@ Additionally, these addrman tracepoints can be helpful during debugging and
 code review. To showcase this, I build a tool that visualizes the addresses
 in the addrman data structure based on the data submitted to the tracepoints.
 
-{{< tweet 1407019872681332742 >}}
+{{< tweet user="0xb10c" id="1407019872681332742" >}}
 
 [Eclipse Attacks]: https://cs-people.bu.edu/heilman/eclipse/
 

--- a/content/blog/example-post.md
+++ b/content/blog/example-post.md
@@ -121,10 +121,10 @@ We can include footnotes[^this-is-a-footnote-ref] by using `[^ref]` where `ref` 
 Hugo offers a built-in tweet shortcode too.
 
 ```
-{{</* tweet 1110302988 */>}}
+{{</* tweet user="halfin" id=1110302988 */>}}
 ```
 
-{{< tweet 1110302988 >}}
+{{< tweet user="halfin" id=1110302988 >}}
 
 
 #### Videos

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,12 +19,12 @@
                       {{ .name }}
                       {{ if isset . "github" }}
                         <a href="https://github.com/{{ .github }}" class="mx-1 image-to-invert">
-                          <img src="/img/footer/github.svg" alt="link to @{{ .github }} on GitHub" height=18 class="d-inline-block align-text-top">
+                          <img src="{{ relURL "img"}}/footer/github.svg" alt="link to @{{ .github }} on GitHub" height=18 class="d-inline-block align-text-top">
                         </a>
                       {{ end }}
                       {{ if isset . "twitter" }}
                         <a href="https://twitter.com/{{ .twitter }}" class="mr-1 image-to-invert">
-                          <img src="/img/footer/twitter.svg" alt="link to @{{ .twitter }} on Twitter" height=18 class="d-inline-block align-text-top">
+                          <img src="{{ relURL "img"}}/footer/twitter.svg" alt="link to @{{ .twitter }} on Twitter" height=18 class="d-inline-block align-text-top">
                         </a>
                       {{ end }}
                     {{ end }}
@@ -35,7 +35,7 @@
                     tagged with
                     {{ $last_tag_index := sub (len . ) 1 }}
                     {{ range $index, $tag := .}}
-                      <a href="/tags/{{ . | urlize }}">{{ . }}</a>{{ if (ne $index ($last_tag_index)) }}, {{ end }}
+                      <a href="{{ relURL "tags"}}/{{ . | urlize }}">{{ . }}</a>{{ if (ne $index ($last_tag_index)) }}, {{ end }}
                     {{ end }}
                   </span>
                 {{ end }}

--- a/layouts/partials/card-small.html
+++ b/layouts/partials/card-small.html
@@ -2,7 +2,7 @@
   <div class="row no-gutters">
     <div class="col-12">
       {{ if .Params.images }}
-      <img src="{{index ( .Params.images ) 0}}" style="object-fit: cover; height: 100%;" class="card-img shadow-sm" alt="Image for {{.Title}}">
+      <img src="{{ relURL ""}}{{index ( .Params.images ) 0}}" style="object-fit: cover; height: 100%;" class="card-img shadow-sm" alt="Image for {{.Title}}">
       {{ end }}
       <a class="stretched-link umami--click--card-sm-img-{{.Title | urlize}}" href="{{.RelPermalink}}"></a>
     </div>

--- a/layouts/partials/card.html
+++ b/layouts/partials/card.html
@@ -2,7 +2,7 @@
   <div class="row row-cols-1 row-cols-md-2">
     {{ if .Params.images }}
       <div class="col col-md-4">
-        <img src="{{index ( .Params.images ) 0}}" style="object-fit: cover; height: 100%;" class="card-img shadow-sm rounded" alt="Image for {{.Title}}">
+        <img src="{{ relURL ""}}{{index ( .Params.images ) 0}}" style="object-fit: cover; height: 100%;" class="card-img shadow-sm rounded" alt="Image for {{.Title}}">
         <a class="stretched-link umami--click--card-img-{{.Title | urlize}}" href="{{.RelPermalink}}"></a>
       </div>
     {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,16 +3,16 @@
   <div class="my-3">
     <!-- icons from https://simpleicons.org -->
     <a rel='me' href="https://twitter.com/bitcoindevblog" class="m-2 image-to-invert umami--click--footer-twitter">
-      <img src="/img/footer/twitter.svg" alt="logo twitter" height=32px>
+      <img src="{{ relURL "img"}}/footer/twitter.svg" alt="logo twitter" height=32px>
     </a>
     <a rel='me' href="https://github.com/dev-bitcoin" class="m-2 image-to-invert umami--click--footer-github">
-      <img src="/img/footer/github.svg" alt="logo github" height=32px>
+      <img src="{{ relURL "img"}}/footer/github.svg" alt="logo github" height=32px>
     </a>
-    <a href="/feed.xml" class="m-2 image-to-invert umami--click--footer-rss-feed">
-      <img src="/img/footer/rss.svg" alt="logo rss" height=32px>
+    <a href="{{ relURL ""}}/feed.xml" class="m-2 image-to-invert umami--click--footer-rss-feed">
+      <img src="{{ relURL "img"}}/footer/rss.svg" alt="logo rss" height=32px>
     </a>
     <a href="mailto:contact[at]bitcoin-dev.blog" class="m-2 image-to-invert umami--click--footer-gmail">
-      <img src="/img/footer/gmail.svg" alt="logo mail" height=32px>
+      <img src="{{ relURL "img"}}/footer/gmail.svg" alt="logo mail" height=32px>
     </a>
   </div>
   <span class="small text-muted">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,12 +11,12 @@
       {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
 
-    <link rel="stylesheet" href="/css/bootstrap.min.css"
+    <link rel="stylesheet" href="{{ relURL "css"}}/bootstrap.min.css"
       integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-    <link rel="stylesheet" href="/css/syntax.css">
-    <link rel="stylesheet" href="/css/index.css">
-    <link rel="shortcut icon" href="/favicon.png" type="image/png">
-    <link rel="icon" href="/favicon.png" type="image/png">
+    <link rel="stylesheet" href="{{ relURL "css"}}/syntax.css">
+    <link rel="stylesheet" href="{{ relURL "css"}}/index.css">
+    <link rel="shortcut icon" href="{{ relURL ""}}/favicon.png" type="image/png">
+    <link rel="icon" href="{{ relURL ""}}/favicon.png" type="image/png">
 
     {{ if not .Site.IsServer }}
     <!-- self-hosted, privacy friendly, and GDPR compliant visitor stats -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
     <link rel="shortcut icon" href="{{ relURL ""}}/favicon.png" type="image/png">
     <link rel="icon" href="{{ relURL ""}}/favicon.png" type="image/png">
 
-    {{ if not .Site.IsServer }}
+    {{ if not hugo.IsServer }}
     <!-- self-hosted, privacy friendly, and GDPR compliant visitor stats -->
     <script async defer
       data-website-id="dfc2acc6-9237-4a34-bc2b-37967cb79a4c"

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar container rounded-bottom shadow-sm mb-4">
   <a class="navbar-brand" href="{{ relURL ""}}/">
-    <img src="/img/logo-large.png" height="50" class="d-inline-block align-baseline image-to-invert mx-2" alt="bitcoin-dev blog logo">
+    <img src="{{ relURL "img"}}/logo-large.png" height="50" class="d-inline-block align-baseline image-to-invert mx-2" alt="bitcoin-dev blog logo">
     <div class="d-inline-block">
       <h1 class="d-block mb-0">bitcoin-dev blog</h1>
       <h6 class="d-block mb-0" style="font-size: calc(0.7rem + 0.7vw)">by and for Bitcoin developers</h6>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 <nav class="navbar container rounded-bottom shadow-sm mb-4">
-  <a class="navbar-brand" href="/">
+  <a class="navbar-brand" href="{{ relURL ""}}/">
     <img src="/img/logo-large.png" height="50" class="d-inline-block align-baseline image-to-invert mx-2" alt="bitcoin-dev blog logo">
     <div class="d-inline-block">
       <h1 class="d-block mb-0">bitcoin-dev blog</h1>

--- a/layouts/shortcodes/center-figure.html
+++ b/layouts/shortcodes/center-figure.html
@@ -4,7 +4,7 @@
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end -}}
-    <img src="{{ .Get "src" }}" class="img img-fluid d-block mx-auto figure-center-img p-3 rounded"
+    <img src="{{ relURL ""}}{{ .Get "src" }}" class="img img-fluid d-block mx-auto figure-center-img p-3 rounded"
          {{- if or (.Get "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}


### PR DESCRIPTION
Once the domain runs out (or preferably before it does), update the blog URL to a GitHub pages URL.

Needs:
- [x] #15 merged
- [x] GitHub pages reconfigured to stop using the bitcoin-dev.blog domain
- [ ] Twitter profile link updated
- [x] GitHub sidebar link updated